### PR TITLE
Adds code to handle multiple versions coming from a build plan

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/cloudfoundry/libcfbuildpack/build"
 	"github.com/cloudfoundry/libcfbuildpack/buildpackplan"
@@ -38,8 +39,11 @@ func NewContributor(context build.Build) (Contributor, bool, error) {
 
 	version := plan.Version
 
-	if plan.Version != "" {
-		rollForwardVersion := plan.Version
+	if version != "" {
+		versions := strings.Split(version, ",")
+		version = versions[0]
+
+		rollForwardVersion := version
 
 		buildpackYAML, err := LoadBuildpackYAML(context.Application.Root)
 		if err != nil {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -35,6 +35,7 @@ func testDotnet(t *testing.T, when spec.G, it spec.S) {
 		when("when there is no buildpack.yml", func() {
 			it("returns true if a build plan exists and matching version is found", func() {
 				factory.AddPlan(buildpackplan.Plan{Name: DotnetRuntime, Version: "2.2.5"})
+				factory.AddPlan(buildpackplan.Plan{Name: DotnetRuntime, Version: "2.2.5"})
 
 				_, willContribute, err := NewContributor(factory.Build)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This is needed for us to handle a case where 2 different plan entries come in with versions. The ShallowMerge code takes those versions and concatenates them together in such a way that breaks the buildpack. We cannot require `dotnet-core-runtime` from the `dotnet-execute` buildpack without these changes.