### PR TITLE
add project file support to plan entry resolver

### DIFF
--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -20,6 +20,7 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 	var (
 		priorities = map[string]int{
 			"buildpack.yml":      3,
+			"project file":       2,
 			"*sproj":             2,
 			"runtimeconfig.json": 2,
 			"":                   -1,

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -1,6 +1,7 @@
 package dotnetcoreruntime
 
 import (
+	"regexp"
 	"sort"
 
 	"github.com/paketo-buildpacks/packit"
@@ -17,16 +18,6 @@ func NewPlanEntryResolver(logger LogEmitter) PlanEntryResolver {
 }
 
 func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.BuildpackPlanEntry {
-	var (
-		priorities = map[string]int{
-			"buildpack.yml":      3,
-			"project file":       2,
-			"*sproj":             2,
-			"runtimeconfig.json": 2,
-			"":                   -1,
-		}
-	)
-
 	sort.Slice(entries, func(i, j int) bool {
 		leftSource := entries[i].Metadata["version-source"]
 		left, _ := leftSource.(string)
@@ -34,7 +25,7 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 		rightSource := entries[j].Metadata["version-source"]
 		right, _ := rightSource.(string)
 
-		return priorities[left] > priorities[right]
+		return getPriority(left) > getPriority(right)
 	})
 
 	chosenEntry := entries[0]
@@ -55,4 +46,25 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 	r.logger.Candidates(entries)
 
 	return chosenEntry
+}
+
+func getPriority(source string) int {
+	var (
+		priorities = map[string]int{
+			"buildpack.yml":      3,
+			`.*proj`:             2,
+			"runtimeconfig.json": 3,
+			"":                   -1,
+		}
+	)
+	if priority, ok := priorities[source]; ok {
+		return priority
+	}
+
+	for key, priority := range priorities {
+		if match, _ := regexp.MatchString(key, source); match {
+			return priority
+		}
+	}
+	return -1
 }

--- a/plan_entry_resolver.go
+++ b/plan_entry_resolver.go
@@ -51,10 +51,10 @@ func (r PlanEntryResolver) Resolve(entries []packit.BuildpackPlanEntry) packit.B
 func getPriority(source string) int {
 	var (
 		priorities = map[string]int{
-			"buildpack.yml":      3,
-			`.*proj`:             2,
-			"runtimeconfig.json": 3,
-			"":                   -1,
+			"buildpack.yml":          3,
+			"runtimeconfig.json":     2,
+			`.*\.(cs)|(fs)|(vb)proj`: 2, // matches filename.(cs/fs/vb)proj
+			"":                       -1,
 		}
 	)
 	if priority, ok := priorities[source]; ok {

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -55,7 +55,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when a buildpack.yml and *proj are both included", func() {
+	context("when a buildpack.yml and proj file are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
@@ -74,7 +74,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-core-runtime",
 					Metadata: map[string]interface{}{
-						"version-source": "**proj",
+						"version-source": "my-app.csproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -89,7 +89,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
 			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      **proj        -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.csproj -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
@@ -133,7 +133,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when a *proj file and unknown are both included", func() {
+	context("when a proj file and unknown are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
@@ -146,7 +146,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-core-runtime",
 					Metadata: map[string]interface{}{
-						"version-source": "**proj",
+						"version-source": "my-app.vbproj",
 						"version":        "project-file-version",
 					},
 				},
@@ -154,13 +154,13 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
 				Name: "dotnet-core-runtime",
 				Metadata: map[string]interface{}{
-					"version-source": "**proj",
+					"version-source": "my-app.vbproj",
 					"version":        "project-file-version",
 				},
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      **proj         -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      my-app.vbproj  -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      unknown source -> \"other-version\""))
 		})
 	})

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -55,7 +55,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when a buildpack.yml and *sproj are both included", func() {
+	context("when a buildpack.yml and *proj are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
@@ -74,46 +74,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-core-runtime",
 					Metadata: map[string]interface{}{
-						"version-source": "*sproj",
-						"version":        "*sproj-version",
-					},
-				},
-			})
-			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name: "dotnet-core-runtime",
-				Metadata: map[string]interface{}{
-					"version-source": "buildpack.yml",
-					"version":        "buildpack-yml-version",
-				},
-			}))
-
-			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      *sproj        -> \"*sproj-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
-		})
-	})
-
-	context("when a buildpack.yml and project file are both included", func() {
-		it("resolves the best plan entry", func() {
-			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
-				{
-					Name: "dotnet-core-runtime",
-					Metadata: map[string]interface{}{
-						"version": "other-version",
-					},
-				},
-				{
-					Name: "dotnet-core-runtime",
-					Metadata: map[string]interface{}{
-						"version-source": "buildpack.yml",
-						"version":        "buildpack-yml-version",
-					},
-				},
-				{
-					Name: "dotnet-core-runtime",
-					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "**proj",
 						"version":        "project-file-version",
 					},
 				},
@@ -128,7 +89,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
 			Expect(buffer.String()).To(ContainSubstring("      buildpack.yml -> \"buildpack-yml-version\""))
-			Expect(buffer.String()).To(ContainSubstring("      project file  -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      **proj        -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"other-version\""))
 		})
 	})
@@ -172,7 +133,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	context("when a project file and unknown are both included", func() {
+	context("when a *proj file and unknown are both included", func() {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
@@ -185,7 +146,7 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 				{
 					Name: "dotnet-core-runtime",
 					Metadata: map[string]interface{}{
-						"version-source": "project file",
+						"version-source": "**proj",
 						"version":        "project-file-version",
 					},
 				},
@@ -193,13 +154,13 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
 				Name: "dotnet-core-runtime",
 				Metadata: map[string]interface{}{
-					"version-source": "project file",
+					"version-source": "**proj",
 					"version":        "project-file-version",
 				},
 			}))
 
 			Expect(buffer.String()).To(ContainSubstring("    Candidate version sources (in priority order):"))
-			Expect(buffer.String()).To(ContainSubstring("      project file   -> \"project-file-version\""))
+			Expect(buffer.String()).To(ContainSubstring("      **proj         -> \"project-file-version\""))
 			Expect(buffer.String()).To(ContainSubstring("      unknown source -> \"other-version\""))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Sophie Wigmore <swigmore@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Look for `project file` as a version source in plan resolver. Look for `*sproj` for now too until all buildpacks in the language family have moved over to `project file` from `*sproj`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
