### PR TITLE
Removes hardcoding of the layer path from integration assertions

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -91,9 +92,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/host`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/%s\/dotnet-core-runtime\/host`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 					MatchRegexp(`drwxr-xr-x \d+ cnb cnb \d+ .* shared`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/%s\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 		})

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/occam"
 	"github.com/paketo-buildpacks/packit/postal"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+
+	. "github.com/onsi/gomega"
 )
 
 var settings struct {

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -121,9 +121,9 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/host`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/%s\/dotnet-core-runtime\/host`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 					MatchRegexp(`drwxr-xr-x \d+ cnb cnb \d+ .* shared`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/%s\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 
@@ -240,9 +240,9 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/host`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/%s\/dotnet-core-runtime\/host`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 					MatchRegexp(`drwxr-xr-x \d+ cnb cnb \d+ .* shared`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/%s\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/occam"
-	. "github.com/paketo-buildpacks/occam/matchers"
 	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
 func testOffline(t *testing.T, context spec.G, it spec.S) {
@@ -92,9 +94,9 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/host`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* host -> \/layers\/%s\/dotnet-core-runtime\/host`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 					MatchRegexp(`drwxr-xr-x \d+ cnb cnb \d+ .* shared`),
-					MatchRegexp(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/paketo-buildpacks_dotnet-core-runtime\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`),
+					MatchRegexp(fmt.Sprintf(`lrwxrwxrwx \d+ cnb cnb   \d+ .* Microsoft.NETCore.App -> \/layers\/%s\/dotnet-core-runtime\/shared\/Microsoft.NETCore.App`, strings.ReplaceAll(settings.BuildpackInfo.Buildpack.ID, "/", "_"))),
 				),
 			)
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This will just use the ID in the buildpack.toml and keep us from coupling to that name specifically.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
