### PR TITLE
Use version 3.0.0 in roll forward test

### DIFF
--- a/integration/rollforward_logging_test.go
+++ b/integration/rollforward_logging_test.go
@@ -64,7 +64,7 @@ func testRollForwardLogging(t *testing.T, context spec.G, it spec.S) {
 					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.BuildpackInfo.Buildpack.Name)),
 					"  Resolving Dotnet Core Runtime version",
 					"    Candidate version sources (in priority order):",
-					"      runtimeconfig.json -> \"2.0.0\"",
+					"      runtimeconfig.json -> \"3.0.0\"",
 					"",
 					"    No exact version match found; attempting version roll-forward",
 					"",

--- a/integration/testdata/rollforward/plan.toml
+++ b/integration/testdata/rollforward/plan.toml
@@ -3,6 +3,6 @@
 
   [requires.metadata]
     launch = true
-    # 2.0.0 is unavailable in the buildpack
-    version = "2.0.0"
+    # 3.0.0 is unavailable in the buildpack
+    version = "3.0.0"
     version-source = "runtimeconfig.json"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Our integration tests are [failing right now](https://github.com/paketo-buildpacks/dotnet-core-runtime/actions/runs/1067559967) on the roll forward test, because the test uses version `2.0.0`, and that version line will be deprecated in about a month, so the logs contain deprecation warnings.

This PR just bumps the version we use to `3.0.0` so that the deprecation warnings aren't present in the logs.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
