### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -98,6 +98,8 @@ func Build(
 				return packit.BuildResult{}, err
 			}
 
+			dotnetCoreRuntimeLayer.Launch, dotnetCoreRuntimeLayer.Build, dotnetCoreRuntimeLayer.Cache = launch, build, build
+
 			return packit.BuildResult{
 				Layers: []packit.Layer{dotnetCoreRuntimeLayer},
 				Build:  buildMetadata,
@@ -113,8 +115,7 @@ func Build(
 			return packit.BuildResult{}, err
 		}
 
-		dotnetCoreRuntimeLayer.Launch, dotnetCoreRuntimeLayer.Build = entries.MergeLayerTypes("dotnet-runtime", context.Plan.Entries)
-		dotnetCoreRuntimeLayer.Cache = dotnetCoreRuntimeLayer.Build
+		dotnetCoreRuntimeLayer.Launch, dotnetCoreRuntimeLayer.Build, dotnetCoreRuntimeLayer.Cache = launch, build, build
 
 		logger.Subprocess("Installing Dotnet Core Runtime %s", dependency.Version)
 		duration, err := clock.Measure(func() error {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/dotnet-core-runtime"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
